### PR TITLE
Rectify broken link of fuse.js library

### DIFF
--- a/main.js
+++ b/main.js
@@ -1,4 +1,4 @@
-class StaticSearchPlugin {
+class StaticFuzzySearchPlugin {
   constructor(API, name, config) {
     this.API = API;
     this.name = name;
@@ -144,7 +144,7 @@ class StaticSearchPlugin {
     const dataUrlForScript = useFeed ? feedUrl : `${indexFileName}`;
 
     // The script references the plugin's bundled fuse.js via the plugin media path
-    const fuseScriptUrl = `${rendererInstance.siteConfig.domain}/media/plugins/staticSearch/fuse.js`;
+    const fuseScriptUrl = `${rendererInstance.siteConfig.domain}/media/plugins/staticFuzzySearch/fuse.js`;
 
     // Render HTML + script
     const output = `
@@ -329,4 +329,4 @@ class StaticSearchPlugin {
   }
 }
 
-module.exports = StaticSearchPlugin;
+module.exports = StaticFuzzySearchPlugin;

--- a/plugin.json
+++ b/plugin.json
@@ -1,9 +1,9 @@
 {
-  "name": "Static Fuzzy Search (Fuzzy + Index)",
+  "name": "Static Fuzzy Search",
   "description": "Combined plugin: generates a customizable search index at build time and provides static fuzzy search using Fuse.js. Backwards-compatible with feed.json. This plugin provides website owners with an easy way to add a fuzzy search functionality to their site. By leveraging the feed.json and fuse.js javascript library, this plugin offers a fast and reliable search experience for users, without the need for a dynamic search engine. With this plugin, site owners can quickly and easily improve the user experience and help visitors find the information they need.",
   "license": "GPL-3.0",
   "author": "Prashant KP & freaks-dev",
-  "version": "2.1",
+  "version": "2.1.2",
   "scope": "site",
   "minimumPubliiVersion": "0.44.0",
   "usePluginSettingsView": false,


### PR DESCRIPTION
minor change to rectify the broken file link structure of fuse.js library due to name change transition from development to production